### PR TITLE
added helper for displaying tags as labels

### DIFF
--- a/meteor/client/main.js
+++ b/meteor/client/main.js
@@ -197,6 +197,23 @@ Handlebars.registerHelper('displayTags', function (tags, delimiter) {
   }
 });
 
+Handlebars.registerHelper('displayTagsAsLabels', function (tags) {
+  if (tags) {
+    // extract name
+    name = tags[0].substr(0, tags[0].indexOf(':'));
+    // special handling for <none> tags, since there's no Handlebars.Utils
+    name = name.replace("<none>", 'none');
+    // build string with labels
+    var returnString = name;
+    tags.forEach(function (entry) {
+      returnString += ' <span class="label label-default">' + entry.substr(entry.indexOf(':') + 1) + '</span>';
+    });
+    return new Handlebars.SafeString(returnString);
+  } else {
+    return '';
+  }
+});
+
 updateBoot2DockerUtilization = function (callback) {
   Boot2Docker.exists(function (err, exists) {
     if (err) { callback(err); return; }

--- a/meteor/client/views/dashboard/apps/dashboard-single-app.html
+++ b/meteor/client/views/dashboard/apps/dashboard-single-app.html
@@ -19,7 +19,7 @@
         {{/if}}
       {{/if}}
       <a onclick="Metrics.trackEvent('container details')" href="/apps/{{name}}" class="name">{{name}}</a>
-      <small><a onclick="Metrics.trackEvent('container view image details')" href="/images/{{image._id}}">{{displayTags image.tags ', '}}</a></small>
+      <small><a onclick="Metrics.trackEvent('container view image details')" href="/images/{{image._id}}">{{displayTagsAsLabels image.tags}}</a></small>
     </h5>
     <div class="options">
       {{#if $eq status 'READY'}}

--- a/meteor/client/views/dashboard/images/dashboard-single-image.html
+++ b/meteor/client/views/dashboard/images/dashboard-single-image.html
@@ -18,7 +18,7 @@
           {{/if}}
         {{/if}}
       {{/if}}
-      <a onclick="Metrics.trackEvent('image details')" href="/images/{{_id}}" class="name">{{displayTags tags ', '}}</a>
+      <a onclick="Metrics.trackEvent('image details')" href="/images/{{_id}}" class="name">{{displayTagsAsLabels tags}}</a>
       {{#if $eq status 'BUILDING'}}
         <small>Creating image. This may take a couple minutes...</small>
       {{else}}


### PR DESCRIPTION
I played around a little bit with the Kitematic source. 
This is not a perfect solution, if you don't like the changes code-wise, please take it as a feature request.

I just thought, that KM could display the tag information in a more condensed way.
It may also be more suitable if not the helper extracts the tags, but some other function beforehand, but I didn't dive too deep into the code.

Anyway, here's how it would look like:

![bildschirmfoto 2014-12-28 um 01 11 31](https://cloud.githubusercontent.com/assets/649031/5562660/04b375fc-8e2f-11e4-98b5-70467662b35d.png)

![bildschirmfoto 2014-12-28 um 01 07 46](https://cloud.githubusercontent.com/assets/649031/5562659/04b34c08-8e2f-11e4-9ad1-e8ebe23a9cf2.png)
