### PR TITLE
Altering the repo name to be a link that takes you to the Docker Hub page

### DIFF
--- a/src/ImageCard.react.js
+++ b/src/ImageCard.react.js
@@ -42,11 +42,11 @@ var ImageCard = React.createClass({
     $tagOverlay.fadeOut(300);
   },
   handleRepoClick: function () {
-    var $repoUri = 'https://registry.hub.docker.com/'
+    var $repoUri = 'https://registry.hub.docker.com/';
     if (this.props.image.is_official) {
-      $repoUri = $repoUri + "_/"
+      $repoUri = $repoUri + "_/";
     } else {
-      $repoUri = $repoUri + "u/"
+      $repoUri = $repoUri + "u/";
     }
     util.exec(['open', $repoUri + this.props.image.name]);
   },
@@ -67,7 +67,7 @@ var ImageCard = React.createClass({
       name = (
         <div>
           <div className="namespace official">{namespace}</div>
-          <OverlayTrigger placement="bottom" overlay={<Tooltip>{this.props.image.name}</Tooltip>}>
+          <OverlayTrigger placement="bottom" overlay={<Tooltip>View on DockerHub</Tooltip>}>
             <span className="repo" onClick={this.handleRepoClick}>{repo}</span>
           </OverlayTrigger>
         </div>

--- a/src/ImageCard.react.js
+++ b/src/ImageCard.react.js
@@ -5,6 +5,7 @@ var ContainerStore = require('./ContainerStore');
 var metrics = require('./Metrics');
 var OverlayTrigger = require('react-bootstrap').OverlayTrigger;
 var Tooltip = require('react-bootstrap').Tooltip;
+var util = require('./Util');
 
 var ImageCard = React.createClass({
   getInitialState: function () {
@@ -40,6 +41,15 @@ var ImageCard = React.createClass({
     var $tagOverlay = $(this.getDOMNode()).find('.tag-overlay');
     $tagOverlay.fadeOut(300);
   },
+  handleRepoClick: function () {
+    var $repoUri = 'https://registry.hub.docker.com/'
+    if (this.props.image.is_official) {
+      $repoUri = $repoUri + "_/"
+    } else {
+      $repoUri = $repoUri + "u/"
+    }
+    util.exec(['open', $repoUri + this.props.image.name]);
+  },
   render: function () {
     var self = this;
     var name;
@@ -58,7 +68,7 @@ var ImageCard = React.createClass({
         <div>
           <div className="namespace official">{namespace}</div>
           <OverlayTrigger placement="bottom" overlay={<Tooltip>{this.props.image.name}</Tooltip>}>
-            <span className="repo">{repo}</span>
+            <span className="repo" onClick={this.handleRepoClick}>{repo}</span>
           </OverlayTrigger>
         </div>
       );
@@ -67,7 +77,7 @@ var ImageCard = React.createClass({
         <div>
           <div className="namespace">{namespace}</div>
           <OverlayTrigger placement="bottom" overlay={<Tooltip>{this.props.image.name}</Tooltip>}>
-            <span className="repo">{repo}</span>
+            <span className="repo" onClick={this.handleRepoClick}>{repo}</span>
           </OverlayTrigger>
         </div>
       );

--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -187,11 +187,6 @@
           text-overflow: ellipsis;
           white-space: nowrap;
           text-decoration: underline;
-          &:hover {
-            background-color: @brand-action;
-            color: white;
-            border-radius: 20px;
-          }
         }
       }
       .description {

--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -186,6 +186,12 @@
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
+          text-decoration: underline;
+          &:hover {
+            background-color: @brand-action;
+            color: white;
+            border-radius: 20px;
+          }
         }
       }
       .description {


### PR DESCRIPTION
Altered the repo name on the ImageCard to open the Docker Hub page for the repo when it is clicked on. I tried to follow the style that you all use for the tag link - though I am not sure that is how you want it to be styled (feel free to change to conform to the standards you are trying to set).

A more advanced version of this might be to open that page within another window.