### PR TITLE
Add X11 abilities to Kitematic

### DIFF
--- a/src/ContainerStore.js
+++ b/src/ContainerStore.js
@@ -139,6 +139,10 @@ var ContainerStore = assign(Object.create(EventEmitter.prototype), {
     }
     existing.kill(function () {
       existing.remove(function () {
+        var x11_display_path = localStorage.getItem('settings.x11DisplayPath');
+        if (x11_display_path) {
+          containerData.Env = ["DISPLAY=" + x11_display_path];
+        }
         docker.client().createContainer(containerData, function (err) {
           if (err) {
             callback(err, null);

--- a/src/Preferences.react.js
+++ b/src/Preferences.react.js
@@ -7,7 +7,8 @@ var Preferences = React.createClass({
   getInitialState: function () {
     return {
       closeVMOnQuit: localStorage.getItem('settings.closeVMOnQuit') === 'true',
-      metricsEnabled: metrics.enabled()
+      metricsEnabled: metrics.enabled(),
+      x11DisplayPath: ""
     };
   },
   handleGoBackClick: function () {
@@ -34,6 +35,13 @@ var Preferences = React.createClass({
       enabled: checked
     });
   },
+  handleDisplayPathChange: function (e) {
+    var display_path = e.target.value;
+    this.setState({
+      x11DisplayPath: display_path
+    });
+    localStorage.setItem('settings.x11DisplayPath', display_path);
+  },
   render: function () {
     return (
       <div className="preferences">
@@ -55,6 +63,14 @@ var Preferences = React.createClass({
             </div>
             <div className="option-value">
               <input type="checkbox" checked={this.state.metricsEnabled} onChange={this.handleChangeMetricsEnabled}/>
+            </div>
+          </div>
+          <div className="option">
+            <div className="option-name">
+              X11 Display path
+            </div>
+            <div className="option-value">
+              <input type="text" onChange={this.handleDisplayPathChange}/>
             </div>
           </div>
         </div>

--- a/src/Preferences.react.js
+++ b/src/Preferences.react.js
@@ -8,7 +8,7 @@ var Preferences = React.createClass({
     return {
       closeVMOnQuit: localStorage.getItem('settings.closeVMOnQuit') === 'true',
       metricsEnabled: metrics.enabled(),
-      x11DisplayPath: ""
+      x11DisplayPath: localStorage.getItem('settings.x11DisplayPath')
     };
   },
   handleGoBackClick: function () {
@@ -70,7 +70,7 @@ var Preferences = React.createClass({
               X11 Display path
             </div>
             <div className="option-value">
-              <input type="text" onChange={this.handleDisplayPathChange}/>
+              <input type="text" onChange={this.handleDisplayPathChange} value={this.state.x11DisplayPath} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This patch will add a new setting variable in the settings view to set a `DISPLAY` path for lunching of X11 containers such as `jess/chrome`.

On unix (untested) you simply fill out the input with "unix:0" (if your current display is 0) and start a X11 container. On Mac OSX you need start a `socat` daemon. Here's an example:

    socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"

With a daemon running you can set the X11 display path to the virtualbox network interface that is running docker ("192.168.59.3:0").

When lunching a container we'll check for the settings file and inject into the container options if it exists.

Try running Chrome with `jess/chrome`!

Fixes #270.