### PR TITLE
A fix required to load only one instance of React in the application. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
     <title>Kitematic</title>
   </head>
   <body>
-    <script src="Main.js"></script>
+    <script src="Startup.js"></script>
   </body>
 </html>

--- a/src/Startup.js
+++ b/src/Startup.js
@@ -1,0 +1,1 @@
+require('./Main');


### PR DESCRIPTION
Without such fix, on windows application loads two instances of React at start time, and crashes.

This is connected to the issue #319 