### PR TITLE
Remove `componentDidMount` function with reload.

### DIFF
--- a/src/ContainerHomePreview.react.js
+++ b/src/ContainerHomePreview.react.js
@@ -37,9 +37,6 @@ var ContainerHomePreview = React.createClass({
       });
     }
   },
-  componentDidUpdate: function () {
-    this.reload();
-  },
   componentWillUnmount: function() {
     clearInterval(this.timer);
   },


### PR DESCRIPTION
Removing the reload (and the whole `componentDidMount` function since the reload was the only thing in there) makes sure that the container view isn't reloaded when the DOM changes and so does not make a request to the container. Because of this change kitematic will not make a request to the container when hovering over the preference button.

(I wasn't sure if this was used somewhere for real. If it is, I couldn't find it).

Fixes #333.