### PR TITLE
Replace hard-coded error message with props.

### DIFF
--- a/src/ContainerHome.react.js
+++ b/src/ContainerHome.react.js
@@ -74,7 +74,9 @@ var ContainerHome = React.createClass({
     if (this.props.error) {
       body = (
         <div className="details-progress">
-          <h3>There was a problem connecting to the Docker Engine in the VirtualBox VM.<br/>This could be caused because this Mac is currently connected to a VPN, blocking access to the VM. If the issue persists, please <a onClick={this.handleErrorClick}>file a ticket on our GitHub repo.</a></h3>
+          <h3>An error occurred:</h3>
+          <h2>{this.props.error}</h2>
+          <h3>If you feel that this error is invalid, please <a onClick={this.handleErrorClick}>file a ticket on our GitHub repo.</a></h3>
           <Radial progress={100} error={true} thick={true} transparent={true}/>
         </div>
       );

--- a/src/ContainerStore.js
+++ b/src/ContainerStore.js
@@ -56,6 +56,12 @@ var ContainerStore = assign(Object.create(EventEmitter.prototype), {
             var data = JSON.parse(str);
             console.log(data);
 
+            if (data.error) {
+              _error = data.error;
+              callback(data.error);
+              return;
+            }
+
             if (data.status && (data.status === 'Pulling dependent layers' || data.status.indexOf('already being pulled by another client') !== -1)) {
               blockedCallback();
               return;
@@ -82,7 +88,8 @@ var ContainerStore = assign(Object.create(EventEmitter.prototype), {
             progressCallback(totalProgress);
           });
           stream.on('end', function () {
-            callback();
+            callback(_error);
+            _error = null;
           });
         });
       });


### PR DESCRIPTION
Make sure that errors that happen when pulling image layers bubble up to the UI. We do this by catching errors coming from the docker client, calling the callback with that error and setting the global variable `_error` as the error we just caught. This is to make sure that when the stream ends we call the callback with the error as well as to not to over-ride it.

Finally we remove the hard-coded message in the UI and display the error that gets passed in to it through the props attribute. This is the only part I'm not super sure on if we really want since it must have been set there for a reason. If I can get a re-producible test case I can make sure that it's still passing with this patch.

Fixes #355.

Signed-off-by: Kristján Oddsson <koddsson@gmail.com>