### PR TITLE
Update tags on mounting ImageCard component.

### DIFF
--- a/src/ContainerHome.react.js
+++ b/src/ContainerHome.react.js
@@ -75,7 +75,7 @@ var ContainerHome = React.createClass({
       body = (
         <div className="details-progress">
           <h3>An error occurred:</h3>
-          <h2>{this.props.error}</h2>
+          <h2>{this.props.error.statusCode} {this.props.error.reason} - {this.props.error.json}</h2>
           <h3>If you feel that this error is invalid, please <a onClick={this.handleErrorClick}>file a ticket on our GitHub repo.</a></h3>
           <Radial progress={100} error={true} thick={true} transparent={true}/>
         </div>

--- a/src/ImageCard.react.js
+++ b/src/ImageCard.react.js
@@ -31,11 +31,11 @@ var ImageCard = React.createClass({
   handleTagOverlayClick: function (name) {
     var $tagOverlay = $(this.getDOMNode()).find('.tag-overlay');
     $tagOverlay.fadeIn(300);
-    $.get('https://registry.hub.docker.com/v1/repositories/' + name + '/tags', function (result) {
+    $.get('https://registry.hub.docker.com/v1/repositories/' + name + '/tags', result => {
       this.setState({
         tags: result
       });
-    }.bind(this));
+    });
   },
   handleCloseTagOverlay: function () {
     var $tagOverlay = $(this.getDOMNode()).find('.tag-overlay');
@@ -51,12 +51,12 @@ var ImageCard = React.createClass({
     util.exec(['open', $repoUri + this.props.image.name]);
   },
   componentDidMount: function() {
-    $.get('https://registry.hub.docker.com/v1/repositories/' + this.props.image.name + '/tags', function (result) {
+    $.get('https://registry.hub.docker.com/v1/repositories/' + this.props.image.name + '/tags', result => {
       this.setState({
         tags: result,
         chosenTag: result[0].name
       });
-    }.bind(this));
+    });
   },
   render: function () {
     var self = this;

--- a/src/ImageCard.react.js
+++ b/src/ImageCard.react.js
@@ -50,6 +50,14 @@ var ImageCard = React.createClass({
     }
     util.exec(['open', $repoUri + this.props.image.name]);
   },
+  componentDidMount: function() {
+    $.get('https://registry.hub.docker.com/v1/repositories/' + this.props.image.name + '/tags', function (result) {
+      this.setState({
+        tags: result,
+        chosenTag: result[0].name
+      });
+    }.bind(this));
+  },
   render: function () {
     var self = this;
     var name;


### PR DESCRIPTION
Should fix #350 in the sense that the error "No command specified" will bubble up to the UI when trying to start a container that has no `CMD` in the Dockerfile.

I made example usage gifs using the `google/debian` image:

- [before](https://cloud.githubusercontent.com/assets/318208/6997501/d318902e-dbac-11e4-881a-f4610fd5e89a.gif)
- [after](https://cloud.githubusercontent.com/assets/318208/6997500/d2d69782-dbac-11e4-8cb7-a6ab25efc262.gif)

This does not fix the "No logs for this container" when booting containers such as the official ubuntu and debian images since they have `CMD` statements in their Dockerfile.

