### PR TITLE
Fall-back to image name as key when there is no id

### DIFF
--- a/src/ContainerList.react.js
+++ b/src/ContainerList.react.js
@@ -9,8 +9,14 @@ var ContainerList = React.createClass({
   render: function () {
     var self = this;
     var containers = this.props.containers.map(function (container) {
+      var container_id = container.Id;
+      if (!container_id && container.State.Downloading) {
+        // Fall back to the container image name when there is no id. (when the
+        // image is downloading).
+        container_id = container.Image;
+      }
       return (
-        <ContainerListItem key={container.Id} container={container} start={self._start}/>
+        <ContainerListItem key={container_id} container={container} start={self._start} />
       );
     });
     var newItem;

--- a/src/ContainerList.react.js
+++ b/src/ContainerList.react.js
@@ -9,14 +9,14 @@ var ContainerList = React.createClass({
   render: function () {
     var self = this;
     var containers = this.props.containers.map(function (container) {
-      var container_id = container.Id;
-      if (!container_id && container.State.Downloading) {
+      var containerId = container.Id;
+      if (!containerId && container.State.Downloading) {
         // Fall back to the container image name when there is no id. (when the
         // image is downloading).
-        container_id = container.Image;
+        containerId = container.Image;
       }
       return (
-        <ContainerListItem key={container_id} container={container} start={self._start} />
+        <ContainerListItem key={containerId} container={container} start={self._start} />
       );
     });
     var newItem;


### PR DESCRIPTION
When a container is first started and the image is downloading there is no id set. With this patch we'll check if the container has a id and and is downloading, if so we'll substitute it with the image name and render such.

This will fix the react key props warning in the developer console as well as maybe give us some sort of performance boost(?)