### PR TITLE
Include boot2docker iso in distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ identity*
 
 # Resources
 resources/docker-*
+resources/boot2docker-*
 
 # Cache
 cache

--- a/src/DockerMachine.js
+++ b/src/DockerMachine.js
@@ -64,7 +64,8 @@ var DockerMachine = {
   },
 
   create: function () {
-    return util.exec([DockerMachine.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', NAME]);
+    var dockerversion = util.packagejson()['docker-version'];
+    return util.exec([DockerMachine.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-boot2docker-url', path.join(process.cwd(), 'resources', 'boot2docker-' + dockerversion + '.iso'), '--virtualbox-memory', '2048', NAME]);
   },
   start: function () {
     return util.exec([DockerMachine.command(), '-D', 'start', NAME]);

--- a/util/deps
+++ b/util/deps
@@ -3,19 +3,20 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BASE=$DIR/..
 DOCKER_MACHINE_CLI_VERSION=$(node -pe "JSON.parse(process.argv[1])['docker-machine-version']" "$(cat $BASE/package.json)")
 DOCKER_MACHINE_CLI_FILE=docker-machine-$DOCKER_MACHINE_CLI_VERSION
-DOCKER_CLI_VERSION=$(node -pe "JSON.parse(process.argv[1])['docker-version']" "$(cat $BASE/package.json)")
-DOCKER_CLI_FILE=docker-$DOCKER_CLI_VERSION
+DOCKER_VERSION=$(node -pe "JSON.parse(process.argv[1])['docker-version']" "$(cat $BASE/package.json)")
+DOCKER_CLI_FILE=docker-$DOCKER_VERSION
+BOOT2DOCKER_FILE=boot2docker-$DOCKER_VERSION.iso
 
 pushd $BASE/resources > /dev/null
 
 if [ ! -f $DOCKER_CLI_FILE ]; then
   echo "-----> Downloading Docker CLI..."
   rm -rf docker-*
-  curl -L -o docker-$DOCKER_CLI_VERSION.tgz https://get.docker.com/builds/Darwin/x86_64/docker-$DOCKER_CLI_VERSION.tgz
-  tar xvzf docker-$DOCKER_CLI_VERSION.tgz --strip=3
-  rm docker-$DOCKER_CLI_VERSION.tgz
-  mv docker docker-$DOCKER_CLI_VERSION
-  chmod +x $DOCKER_CLI_FILE
+  curl -L -o docker-$DOCKER_VERSION.tgz https://get.docker.com/builds/Darwin/x86_64/docker-$DOCKER_VERSION.tgz
+  tar xvzf docker-$DOCKER_VERSION.tgz --strip=3
+  rm docker-$DOCKER_VERSION.tgz
+  mv docker docker-$DOCKER_VERSION
+  chmod +x $DOCKER_VERSION
 fi
 
 if [ ! -f $DOCKER_MACHINE_CLI_FILE ]; then
@@ -24,5 +25,12 @@ if [ ! -f $DOCKER_MACHINE_CLI_FILE ]; then
   curl -L -o $DOCKER_MACHINE_CLI_FILE https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_CLI_VERSION/docker-machine_darwin-amd64
   chmod +x $DOCKER_MACHINE_CLI_FILE
 fi
+
+if [ ! -f $BOOT2DOCKER_FILE ]; then
+  echo "-----> Downloading Boot2Docker iso..."
+  rm -rf boot2docker-*
+  curl -L -o $BOOT2DOCKER_FILE https://github.com/boot2docker/boot2docker/releases/download/v$DOCKER_VERSION/boot2docker.iso
+fi
+
 
 popd > /dev/null


### PR DESCRIPTION
- Fixes bug where boot2docker.iso can't be downloaded (due to timeout, GitHub API limit hit, etc.)