### PR TITLE
Adding sourcemaps to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "jest": {
     "scriptPreprocessor": "<rootDir>/util/preprocessor.js",
     "setupEnvScriptFile": "<rootDir>/util/testenv.js",
+    "setupTestFrameworkScriptFile": "<rootDir>/util/prepare.js",
     "collectCoverage": true,
     "testDirectoryName": "src",
     "testPathIgnorePatterns": [
@@ -42,7 +43,8 @@
       "<rootDir>/node_modules/.*JSONStream",
       "<rootDir>/node_modules/object-assign",
       "<rootDir>/node_modules/underscore",
-      "<rootDir>/node_modules/bluebird"
+      "<rootDir>/node_modules/bluebird",
+      "<rootDir>/node_modules/source-map-support"
     ]
   },
   "docker-version": "1.6.0",
@@ -52,6 +54,7 @@
   "virtualbox-filename": "VirtualBox-4.3.26.pkg",
   "virtualbox-checksum": "668f61c95efe37f8fc65cafe95b866fba64e37f2492dfc1e2b44a7ac3dcafa3b",
   "dependencies": {
+    "alt": "^0.15.6",
     "ansi-to-html": "0.3.0",
     "async": "^0.9.0",
     "bluebird": "^2.9.24",
@@ -93,6 +96,7 @@
     "jsxhint": "^0.14.0",
     "minimist": "^1.1.1",
     "react-tools": "^0.13.1",
-    "run-sequence": "^1.0.2"
+    "run-sequence": "^1.0.2",
+    "source-map-support": "^0.2.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "virtualbox-filename": "VirtualBox-4.3.26.pkg",
   "virtualbox-checksum": "668f61c95efe37f8fc65cafe95b866fba64e37f2492dfc1e2b44a7ac3dcafa3b",
   "dependencies": {
-    "alt": "^0.15.6",
     "ansi-to-html": "0.3.0",
     "async": "^0.9.0",
     "bluebird": "^2.9.24",

--- a/src/alt.js
+++ b/src/alt.js
@@ -1,0 +1,2 @@
+var Alt = require('alt');
+module.exports = new Alt();

--- a/src/alt.js
+++ b/src/alt.js
@@ -1,2 +1,0 @@
-var Alt = require('alt');
-module.exports = new Alt();

--- a/util/prepare.js
+++ b/util/prepare.js
@@ -1,0 +1,14 @@
+require.requireActual('babel/polyfill');
+require.requireActual('source-map-support').install({
+  retrieveSourceMap: function(filename) {
+    if (filename.indexOf('node_modules') === -1) {
+      try {
+        return {
+          map: require.requireActual('fs').readFileSync('/tmp/' + require('crypto').createHash('md5').update(filename).digest('hex') + '.map', 'utf8')
+        };
+      } catch (err) {
+        return undefined;
+      }
+    }
+  }
+});

--- a/util/preprocessor.js
+++ b/util/preprocessor.js
@@ -1,12 +1,14 @@
+var babel = require('babel');
+var fs = require('fs');
+var crypto = require('crypto');
+
 module.exports = {
   process: function(src, filename) {
-    if (filename.indexOf('node_modules') === -1) {
-      var res = require('babel').transform(src).code;
-      if (filename.indexOf('-test') !== -1) {
-        res = 'require(\'babel/polyfill\');' + res;
-      }
-      return res;
+    if (filename.indexOf('node_modules') !== -1) {
+      return src;
     }
-    return src;
+    var compiled = babel.transform(src, {filename: filename, sourceMap: true});
+    fs.writeFileSync('/tmp/' + crypto.createHash('md5').update(filename).digest('hex') + '.map', JSON.stringify(compiled.map));
+    return compiled.code;
   }
 };


### PR DESCRIPTION
This makes test output much easier to read by showing the correct lines where tests fail or errors occur.