### PR TITLE
Add info about what the pre-requisites are

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Before you fil an issue or a pull request, quickly read of the following tips on
 
 ## Table of Contents
 
+ - [Prerequisites](#prerequisites)
  - [Getting Started](#getting-started)
  - [Architecture](#architecture)
  - [GitHub Issues](#github-issues)
@@ -13,6 +14,17 @@ Before you fil an issue or a pull request, quickly read of the following tips on
  - [Code Guidelines](#code-guidelines)
  - [Testing](#testing)
  - [License](#license)
+
+### Prerequisites
+
+Most of the time, you'll have installed Kitematic before contibuting, but for the
+sake of completeness, you can also install [Node.js](https://nodejs.org/) and then
+run from your Git clone.
+
+Running `npm start` will download and install [Docker machine](https://github.com/docker/machine),
+the [Boot2Docker iso](https://github.com/boot2docker/boot2docker),
+[Electron](http://electron.atom.io/), and [VirtualBox](https://www.virtualbox.org/)
+if needed.
 
 ### Getting Started
 


### PR DESCRIPTION
Need to think about minimum versions, as it upgraded some thing, but not vbox

Signed-off-by: Sven Dowideit <SvenDowideit@docker.com>

does it download and upgrade the docker client too? (I think so, as my older setup suddenly broke)

I suspect we're best off making the default PATH contain the latest - `boot2docker upgrade` is also rude in this way, but perhaps we should warn and confirm that we're about to do something that could break a carefully setup old docker&vm config someone is busy using.