### PR TITLE
Fixing setting up custom shell in container terminal

### DIFF
--- a/src/components/ContainerDetailsSubheader.react.js
+++ b/src/components/ContainerDetailsSubheader.react.js
@@ -102,7 +102,11 @@ var ContainerDetailsSubheader = React.createClass({
     if (!this.disableTerminal()) {
       metrics.track('Terminaled Into Container');
       var container = this.props.container;
-      var shell = ContainerUtil.env(container).SHELL;
+      var shell = ContainerUtil.env(container).reduce((envs, env) => {
+        envs[env[0]] = env[1];
+        return envs;
+      }, {}).SHELL;
+
       if(typeof shell === 'undefined') {
         shell = 'sh';
       }

--- a/src/components/ContainerDetailsSubheader.react.js
+++ b/src/components/ContainerDetailsSubheader.react.js
@@ -107,7 +107,7 @@ var ContainerDetailsSubheader = React.createClass({
         return envs;
       }, {}).SHELL;
 
-      if(typeof shell === 'undefined') {
+      if(!shell) {
         shell = 'sh';
       }
       machine.ip().then(ip => {


### PR DESCRIPTION
Hey guys,
i wanted to set custom shell to `bash` instead of `sh` which is default. I set environment `ENV SHELL /bin/bash`, but it was still picking up default option `sh` every time. I have found in code when you trying to check if somebody wants to set custom shell that you are accessing to array like to object, so i have added simple reduce function to make it actually object.

Hopefully everything is ok ;)

Let me know if you have any questions.
Vojta

Signed-off-by: Vojta Bartos <hi@vojtech.me>