### PR TITLE
Linux groundwork

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -301,6 +301,10 @@ gulp.task('default', ['download-docker', 'download-docker-machine', 'download-do
       gulp.src('').pipe(shell(['cache\\electron.exe .'], {
           env: env
       }));
+  } else if(process.platform === 'linux') {
+      gulp.src('').pipe(shell(['./cache/electron ./'], {
+          env: env
+      }));
   } else {
       gulp.src('').pipe(shell(['./cache/Electron.app/Contents/MacOS/Electron .'], {
           env: env

--- a/src/utils/MetricsUtil.js
+++ b/src/utils/MetricsUtil.js
@@ -47,7 +47,7 @@ var Metrics = {
 
     var os;
 
-    if(util.isWindows()) {
+    if(util.isWindows() || util.isLinux()) {
       os = navigator.userAgent;
     } else {
       os = navigator.userAgent.match(/Mac OS X (\d+_\d+_\d+)/)[1].replace(/_/g, '.');

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -23,6 +23,9 @@ module.exports = {
   isWindows: function () {
     return process.platform === 'win32';
   },
+  isLinux: function () {
+    return process.platform === 'linux';
+  },
   binsPath: function () {
     return this.isWindows() ? path.join(this.home(), 'Kitematic-bins') : path.join('/usr/local/bin');
   },


### PR DESCRIPTION
Allow to download dependencies and start kitematic under Linux using npm start.

ref #49