### PR TITLE
Fixed stale log refresh

### DIFF
--- a/src/stores/ContainerStore.js
+++ b/src/stores/ContainerStore.js
@@ -3,6 +3,7 @@ import deepExtend from 'deep-extend';
 import alt from '../alt';
 import containerServerActions from '../actions/ContainerServerActions';
 import containerActions from '../actions/ContainerActions';
+var LogStore = require('./LogStore');
 
 class ContainerStore {
   constructor () {
@@ -87,6 +88,8 @@ class ContainerStore {
     if (!containers[container.Name] || containers[container.Name].State.Updating) {
       return;
     }
+    // Trigger log update
+    LogStore.fetch(container.Name);
 
     containers[container.Name] = container;
 


### PR DESCRIPTION
Previous logs only updated when the component mounted, this fix allows for logs to be refreshed whenever the actual container is updated, usually triggered by `containerServerActions.updated({container})`

This should fix issue https://github.com/kitematic/kitematic/issues/535

Signed-off-by: TeckniX <lokitek@gmail.com>