### PR TITLE
Fixed scrollbottom

### DIFF
--- a/src/components/ContainerHomeLogs.react.js
+++ b/src/components/ContainerHomeLogs.react.js
@@ -43,7 +43,7 @@ module.exports = React.createClass({
   },
   scrollToBottom: function () {
     var parent = $('.logs');
-    if (parent.scrollTop() >= _prevBottom - 50) {
+    if (parent[0].scrollHeight - parent.height() >= _prevBottom - 50) {
       parent.scrollTop(parent[0].scrollHeight - parent.height());
     }
     _prevBottom = parent[0].scrollHeight - parent.height();


### PR DESCRIPTION
After the UI update it seems that the logs didn't properly scroll automatically to the bottom.  This should fix this issue. 

Signed-off-by: TeckniX <lokitek@gmail.com>