### PR TITLE
Added support for docker tty stdin options

### DIFF
--- a/src/components/ContainerSettingsGeneral.react.js
+++ b/src/components/ContainerSettingsGeneral.react.js
@@ -22,7 +22,7 @@ var ContainerSettingsGeneral = React.createClass({
       return [util.randomId(), e[0], e[1]];
     });
 
-    let [tty, openStdin] = ContainerUtil.mode(this.props.container) || [false, false];
+    let [tty, openStdin] = ContainerUtil.mode(this.props.container) || [true, true];
 
     return {
       slugName: null,
@@ -232,7 +232,7 @@ var ContainerSettingsGeneral = React.createClass({
         </div>
         <div className="settings-section">
           <div className="env-vars">
-            <h4>Foreground Options</h4>
+            <h4>Advanced Options</h4>
             <p><input type="checkbox" checked={this.state.tty} onChange={this.handleChangeTty}/> Attach standard streams to a tty, including stdin if it is not closed</p>
             <p><input type="checkbox" checked={this.state.openStdin} onChange={this.handleChangeOpenStdin}/> Keep STDIN open even if not attached</p>
           </div>

--- a/src/components/ContainerSettingsGeneral.react.js
+++ b/src/components/ContainerSettingsGeneral.react.js
@@ -22,10 +22,14 @@ var ContainerSettingsGeneral = React.createClass({
       return [util.randomId(), e[0], e[1]];
     });
 
+    let [tty, openStdin] = ContainerUtil.mode(this.props.container) || [false, false];
+
     return {
       slugName: null,
       nameError: null,
-      env: env
+      env: env,
+      tty: tty,
+      openStdin: openStdin
     };
   },
 
@@ -90,7 +94,9 @@ var ContainerSettingsGeneral = React.createClass({
         list.push(key + '=' + value);
       }
     });
-    containerActions.update(this.props.container.Name, {Env: list});
+    let tty = this.state.tty;
+    let openStdin = this.state.openStdin;
+    containerActions.update(this.props.container.Name, {Env: list, Tty: tty, OpenStdin: openStdin});
   },
 
   handleChangeEnvKey: function (index, event) {
@@ -131,6 +137,18 @@ var ContainerSettingsGeneral = React.createClass({
     });
 
     metrics.track('Removed Environment Variable');
+  },
+
+  handleChangeTty: function () {
+    this.setState({
+      tty: !this.state.tty
+    });
+  },
+
+  handleChangeOpenStdin: function () {
+    this.setState({
+      openStdin: !this.state.openStdin
+    });
   },
 
   handleDeleteContainer: function () {
@@ -210,6 +228,13 @@ var ContainerSettingsGeneral = React.createClass({
           </div>
           <div className="env-vars">
             {vars}
+          </div>
+        </div>
+        <div className="settings-section">
+          <div className="env-vars">
+            <h4>Foreground Options</h4>
+            <p><input type="checkbox" checked={this.state.tty} onChange={this.handleChangeTty}/> Attach standard streams to a tty, including stdin if it is not closed</p>
+            <p><input type="checkbox" checked={this.state.openStdin} onChange={this.handleChangeOpenStdin}/> Keep STDIN open even if not attached</p>
           </div>
           <a className="btn btn-action" disabled={this.props.container.State.Updating} onClick={this.handleSaveEnvVars}>Save</a>
         </div>

--- a/src/utils/ContainerUtil.js
+++ b/src/utils/ContainerUtil.js
@@ -16,7 +16,7 @@ var ContainerUtil = {
   // Provide Foreground options
   mode: function (container) {
     if (!container || !container.Config) {
-      return [false, false];
+      return [true, true];
     }
     return [container.Config.Tty, container.Config.OpenStdin];
   },

--- a/src/utils/ContainerUtil.js
+++ b/src/utils/ContainerUtil.js
@@ -13,6 +13,14 @@ var ContainerUtil = {
     });
   },
 
+  // Provide Foreground options
+  mode: function (container) {
+    if (!container || !container.Config) {
+      return [false, false];
+    }
+    return [container.Config.Tty, container.Config.OpenStdin];
+  },
+
   // TODO: inject host here instead of requiring Docker
   ports: function (container) {
     if (!container || !container.NetworkSettings) {

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -25,8 +25,6 @@ export default {
       throw new Error('Certificate directory does not exist');
     }
 
-    console.log(ip);
-
     this.host = ip;
     this.client = new dockerode({
       protocol: 'https',
@@ -103,6 +101,7 @@ export default {
       containerData.Env = containerData.Config.Env;
     }
 
+
     containerData.Volumes = _.mapObject(containerData.Volumes, () => {return {};});
 
     let existing = this.client.getContainer(name);
@@ -162,6 +161,8 @@ export default {
       Config: {
         Image: imageName,
       },
+      Tty: true,
+      OpenStdin: true,
       State: {
         Downloading: true
       }
@@ -183,7 +184,7 @@ export default {
 
       delete this.placeholders[name];
       localStorage.setItem('placeholders', JSON.stringify(this.placeholders));
-      this.createContainer(name, {Image: imageName});
+      this.createContainer(name, {Image: imageName, Tty: true, OpenStdin: true});
     },
 
     // progress is actually the progression PER LAYER (combined in columns)


### PR DESCRIPTION
I've been using busybox-like data containers and noticed that for some it was needed to add `docker run -ti` options to have a pseudo-tty allocated to the container otherwise the container wouldn't stay running. 

Since `-i -t` are commonly added together, it was only normal to also support that option. 

Signed-off-by: TeckniX <lokitek@gmail.com>

Look and feel:
![kitematic screen shot](https://cloud.githubusercontent.com/assets/33699/8215630/3ed42a54-14ff-11e5-8cbc-996717df7076.png)
