### PR TITLE
Improve performance by hitting the remote api less

### DIFF
--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -4,7 +4,6 @@ import dockerUtil from '../utils/DockerUtil';
 class ContainerActions {
 
   destroy (name) {
-    this.dispatch({name});
     dockerUtil.destroy(name);
   }
 

--- a/src/components/ContainerListItem.react.js
+++ b/src/components/ContainerListItem.react.js
@@ -21,8 +21,8 @@ var ContainerListItem = React.createClass({
     e.preventDefault();
     e.stopPropagation();
     dialog.showMessageBox({
-      message: 'Are you sure you want to delete this container?',
-      buttons: ['Delete', 'Cancel']
+      message: 'Are you sure you want to stop & remove this container?',
+      buttons: ['Remove', 'Cancel']
     }, function (index) {
       if (index === 0) {
         metrics.track('Deleted Container', {

--- a/src/stores/ContainerStore.js
+++ b/src/stores/ContainerStore.js
@@ -83,7 +83,7 @@ class ContainerStore {
 
   updated ({container}) {
     let containers = this.containers;
-    if (!containers[container.Name] || containers[container.Name].State.Updating) {
+    if (containers[container.Name] && containers[container.Name].State.Updating) {
       return;
     }
     // Trigger log update
@@ -111,16 +111,10 @@ class ContainerStore {
     this.setState({containers});
   }
 
-  destroy ({name}) {
-    let containers = this.containers;
-    delete containers[name];
-    this.setState({containers});
-  }
-
-  destroyed ({name}) {
+  destroyed ({id}) {
     let containers = this.containers;
     let container = _.find(_.values(this.containers), container => {
-      return container.Id === name || container.Name === name;
+      return container.Id === id || container.Name === id;
     });
 
     if (container && container.State && container.State.Updating) {

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -135,23 +135,27 @@ export default {
       if (err) {
         return;
       }
-      async.map(containers, (container, callback) => {
-        this.client.getContainer(container.Id).inspect((error, container) => {
-          if (error) {
-            callback(null, null);
-            return;
-          }
-          container.Name = container.Name.replace('/', '');
-          callback(null, container);
-        });
-      }, (err, containers) => {
-        containers = containers.filter(c => c !== null);
-        if (err) {
-          // TODO: add a global error handler for this
-          return;
+
+      let modifiedContainers = _.map(containers, container => {
+        container.Name = container.Names[0].replace('/', '');
+        delete container.Names;
+
+        // HACK: fill in some data based on simple list data
+        container.State = {};
+        container.Config = {
+          Image: container.Image
+        };
+        if (container.Status.indexOf('Exited') !== -1) {
+          container.State.Stopped = true;
+        } else if (container.Status.indexOf('Paused') !== -1) {
+          container.State.Stopped = true;
+        } else if (container.Status.indexOf('Up') !== -1) {
+          container.State.Running = true;
         }
-        containerServerActions.allUpdated({containers: _.indexBy(containers.concat(_.values(this.placeholders)), 'Name')});
+        return container;
       });
+      console.log(modifiedContainers);
+      containerServerActions.allUpdated({containers: _.indexBy(modifiedContainers.concat(_.values(this.placeholders)), 'Name')});
     });
   },
 
@@ -333,10 +337,10 @@ export default {
           return;
         }
 
+        console.log(data);
+
         if (data.status === 'destroy') {
-          containerServerActions.destroyed({name: data.id});
-        } else if (data.status === 'create') {
-          this.fetchAllContainers();
+          containerServerActions.destroyed({id: data.id});
         } else {
           this.fetchContainer(data.id);
         }

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -338,7 +338,7 @@ export default {
 
         if (data.status === 'destroy') {
           containerServerActions.destroyed({id: data.id});
-        } else {
+        } else if (data.id) {
           this.fetchContainer(data.id);
         }
       });

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -154,7 +154,6 @@ export default {
         }
         return container;
       });
-      console.log(modifiedContainers);
       containerServerActions.allUpdated({containers: _.indexBy(modifiedContainers.concat(_.values(this.placeholders)), 'Name')});
     });
   },
@@ -336,8 +335,6 @@ export default {
         if (data.status === 'pull' || data.status === 'untag' || data.status === 'delete') {
           return;
         }
-
-        console.log(data);
 
         if (data.status === 'destroy') {
           containerServerActions.destroyed({id: data.id});


### PR DESCRIPTION
Tentatively fixes #687

- Don't reload every container's data when a create event occurs
- Upon loading don't relead every container

This should reduce the O(N^2) cost we saw before by fetching _every_ container on every event.

Note: this will still cause some overhead since it calls `/container/inspect` for every `create`, roughly 150ms per create.