### PR TITLE
Implement a configurable 'Debug' tab on containers

### DIFF
--- a/src/actions/ContainerActions.js
+++ b/src/actions/ContainerActions.js
@@ -39,6 +39,12 @@ class ContainerActions {
   run (name, repo, tag) {
     dockerUtil.run(name, repo, tag);
   }
+
+  inspect (name, component, callback) {
+    dockerUtil.inspectContainer(name, function (result) {
+      callback(result, component);
+    });
+  }
 }
 
 export default alt.createActions(ContainerActions);

--- a/src/components/ContainerDebug.react.js
+++ b/src/components/ContainerDebug.react.js
@@ -1,0 +1,47 @@
+var React = require('react/addons');
+var containerActions = require('../actions/ContainerActions');
+
+var ContainerDebug = React.createClass({
+
+  getInitialState: function () {
+    return {
+      containerJson: null
+    }
+  },
+
+  componentDidMount: function() {
+    if (!this.props.container) {
+      return;
+    }
+
+    this.fetchContainerJson();
+  },
+
+  fetchContainerJson: function () {
+    containerActions.inspect(this.props.container.Name, this, function (result, component) {
+      var containerJsonString = JSON.stringify(result, null, 4);
+      component.setState({
+        containerJson: containerJsonString
+      });
+    });
+  },
+
+  render: function () {
+    if (!this.props.container) {
+      return false;
+    }
+
+    return (
+      <div className="details-panel">
+        <div className="settings">
+          <div className="settings-panel">
+            <h3>Container inspector</h3>
+            <pre className="selectable-text">{this.state.containerJson}</pre>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ContainerDebug;

--- a/src/components/ContainerDetailsSubheader.react.js
+++ b/src/components/ContainerDetailsSubheader.react.js
@@ -61,6 +61,12 @@ var ContainerDetailsSubheader = React.createClass({
       this.context.router.transitionTo('containerSettings', {name: this.context.router.getCurrentParams().name});
     }
   },
+  showDebug: function () {
+    if (!this.disableTab()) {
+      metrics.track('Viewed Debug');
+      this.context.router.transitionTo('containerDebug', {name: this.context.router.getCurrentParams().name});
+    }
+  },
   handleRun: function () {
     if (this.props.defaultPort && !this.disableRun()) {
       metrics.track('Opened In Browser', {
@@ -133,6 +139,11 @@ var ContainerDetailsSubheader = React.createClass({
       'active': currentRoutes && (currentRoutes.indexOf('containerSettings') >= 0),
       disabled: this.disableTab()
     });
+    var tabDebugClasses = classNames({
+      'details-tab': true,
+      'active': currentRoutes && (currentRoutes.indexOf('containerDebug') >= 0),
+      disabled: this.disableTab()
+    });
     var startStopToggle;
     if (this.disableStop()) {
       startStopToggle = (
@@ -149,6 +160,14 @@ var ContainerDetailsSubheader = React.createClass({
         </div>
       );
     }
+
+    let debugTab;
+    if (localStorage.getItem('settings.debugEnabled') === 'true') {
+      debugTab = (
+        <span className={tabDebugClasses} onClick={this.showDebug}>Debug</span>
+      );
+    }
+
     return (
       <div className="details-subheader">
         <div className="details-header-actions">
@@ -165,6 +184,7 @@ var ContainerDetailsSubheader = React.createClass({
         <div className="details-subheader-tabs">
           <span className={tabHomeClasses} onClick={this.showHome}>Home</span>
           <span className={tabSettingsClasses} onClick={this.showSettings}>Settings</span>
+          {debugTab}
         </div>
       </div>
     );

--- a/src/components/Preferences.react.js
+++ b/src/components/Preferences.react.js
@@ -7,6 +7,7 @@ var Preferences = React.createClass({
   getInitialState: function () {
     return {
       closeVMOnQuit: localStorage.getItem('settings.closeVMOnQuit') === 'true',
+      debugEnabled: localStorage.getItem('settings.debugEnabled') === 'true',
       metricsEnabled: metrics.enabled()
     };
   },
@@ -34,6 +35,16 @@ var Preferences = React.createClass({
       enabled: checked
     });
   },
+  handleChangeDebugEnabled: function (e) {
+    var checked = e.target.checked;
+    this.setState({
+      debugEnabled: checked
+    });
+    localStorage.setItem('settings.debugEnabled', checked);
+    metrics.track('Toggled Enable "Debug" tab', {
+      enabled: checked
+    });
+  },
   render: function () {
     return (
       <div className="preferences">
@@ -55,6 +66,15 @@ var Preferences = React.createClass({
             </div>
             <div className="option-value">
               <input type="checkbox" checked={this.state.metricsEnabled} onChange={this.handleChangeMetricsEnabled}/>
+            </div>
+          </div>
+          <div className="title">Developer tools</div>
+          <div className="option">
+            <div className="option-name">
+              Enable "Debug" tab
+            </div>
+            <div className="option-value">
+              <input type="checkbox" checked={this.state.debugEnabled} onChange={this.handleChangeDebugEnabled}/>
             </div>
           </div>
         </div>

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,6 +12,7 @@ var ContainerSettingsGeneral = require('./components/ContainerSettingsGeneral.re
 var ContainerSettingsPorts = require('./components/ContainerSettingsPorts.react');
 var ContainerSettingsVolumes = require('./components/ContainerSettingsVolumes.react');
 var ContainerSettingsAdvanced = require('./components/ContainerSettingsAdvanced.react');
+var ContainerDebug = require('./components/ContainerDebug.react');
 var Preferences = require('./components/Preferences.react');
 var NewContainerSearch = require('./components/NewContainerSearch.react');
 var NewContainerPull = require('./components/NewContainerPull.react');
@@ -45,6 +46,7 @@ var routes = (
           <Route name="containerSettingsVolumes" path="containers/details/:name/settings/volumes" handler={ContainerSettingsVolumes}/>
           <Route name="containerSettingsAdvanced" path="containers/details/:name/settings/advanced" handler={ContainerSettingsAdvanced}/>
         </Route>
+        <Route name="containerDebug" path="containers/details/:name/debug" handler={ContainerDebug}/>
       </Route>
       <Route name="new" path="containers/new">
         <DefaultRoute name="search" handler={NewContainerSearch}/>

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -228,6 +228,13 @@ export default {
     });
   },
 
+  inspectContainer (name, callback) {
+    let existing = this.client.getContainer(name);
+    existing.inspect((error, existingData) => {
+      callback(existingData);
+    });
+  },
+
   rename (name, newName) {
     this.client.getContainer(name).rename({name: newName}, error => {
       if (error && error.statusCode !== 204) {

--- a/styles/container-debug.less
+++ b/styles/container-debug.less
@@ -1,0 +1,3 @@
+pre.selectable-text {
+  -webkit-user-select: all;
+}

--- a/styles/main.less
+++ b/styles/main.less
@@ -18,6 +18,7 @@
 @import "spinner.less";
 @import "animation.less";
 @import "container-progress.less";
+@import "container-debug.less";
 
 html, body {
   height: 100%;


### PR DESCRIPTION
This pull request add a new option

![screenshot from 2015-06-25 20 07 13](https://cloud.githubusercontent.com/assets/478564/8361792/62ec6d94-1b75-11e5-9c18-a87580a2cb5a.png)

Which then add a new tab (when debug enabled) which shows the JSON representation of the selected container at the moment you open the tab:

![screenshot from 2015-06-25 20 08 36](https://cloud.githubusercontent.com/assets/478564/8361821/915ae0a2-1b75-11e5-9d49-9a30f13ae866.png)

I needed this as I'm implementing the Volumes management in order to fix issue #376.