### PR TITLE
Fixed Tty and Stdin save

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -220,6 +220,11 @@ export default {
         existingData.Env = existingData.Config.Env;
       }
 
+      if ((!existingData.Tty || !existingData.OpenStdin) && existingData.Config && (existingData.Config.Tty || existingData.Config.OpenStdin)) {
+        existingData.Tty = existingData.Config.Tty;
+        existingData.OpenStdin = existingData.Config.OpenStdin;
+      }
+
       var fullData = _.extend(existingData, data);
       this.createContainer(name, fullData);
     });


### PR DESCRIPTION
Previous TTY/Stdin settings weren't kept if General/Volumes/Ports were modified and save - This fixes the issue by reading the Container data before the update.

Signed-off-by: TeckniX <lokitek@gmail.com>