### PR TITLE
Fixes error of docker CLI not working under zsh

### DIFF
--- a/resources/terminal
+++ b/resources/terminal
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PATH=$DIR:$PATH
-CMD="export PATH='$PATH' && clear && $*"
+CMD="export PATH='$PATH' &&clear"
 
 ITERM_EXISTS=`osascript <<EOF
 set doesExist to false
@@ -21,14 +21,14 @@ function open_iterm () {
       tell the first terminal
         launch session "Default Session"
         tell the last session
-          write text "bash -c \"$CMD\""
+          write text "$CMD"
         end tell
       end tell
     on error
       tell (make new terminal)
         launch session "Default Session"
         tell the last session
-          write text "bash -c \"$CMD\""
+          write text "$CMD"
         end tell
       end tell
     end try
@@ -42,7 +42,7 @@ function open_terminal () {
   delay 0.4
   tell application "System Events" to keystroke "t" using command down
   tell application "Terminal"
-    do script "bash -c \"$CMD\"" in window 1
+    do script "$CMD" in window 1
   end tell
 EOF
 }


### PR DESCRIPTION
This commit fixes issue #755. zsh is a common shell alternative on OS X but the terminal script assumes the bash shell. I made a few simple changes to make the script work in both bash and zsh.
