### PR TITLE
URGENT: Fixed iso and version issues

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -14,10 +14,10 @@ var DockerMachine = {
   name: function () {
     return NAME;
   },
-  isoversion: function () {
+  isoversion: function (machineName = this.name()) {
     try {
-      var data = fs.readFileSync(path.join(util.home(), '.docker', 'machine', 'machines', NAME, 'boot2docker.iso'), 'utf8');
-      var match = data.match(/Boot2Docker-v(\d+\.\d+\.\d+)/);
+      var data = fs.readFileSync(path.join(util.home(), '.docker', 'machine', 'machines', machineName, 'boot2docker-virtualbox.iso'), 'utf8');
+      var match = data.match(/Docker v(\d+\.\d+\.\d+)/);
       if (match) {
         return match[1];
       } else {
@@ -27,7 +27,7 @@ var DockerMachine = {
       return null;
     }
   },
-  info: function () {
+  info: function (machineName = this.name()) {
     return util.exec([this.command(), 'ls']).then(stdout => {
       var lines = stdout.trim().split('\n').filter(line => line.indexOf('time=') === -1);
       var machines = {};
@@ -41,50 +41,50 @@ var DockerMachine = {
         };
         machines[machine.name] = machine;
       });
-      if (machines[NAME]) {
-        return Promise.resolve(machines[NAME]);
+      if (machines[machineName]) {
+        return Promise.resolve(machines[machineName]);
       } else {
         return Promise.reject(new Error('Machine does not exist.'));
       }
     });
   },
-  exists: function () {
-    return this.info().then(() => {
+  exists: function (machineName = this.name()) {
+    return this.info(machineName).then(() => {
       return true;
     }).catch(() => {
       return false;
     });
   },
-  create: function () {
-    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', NAME]);
+  create: function (machineName = this.name()) {
+    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', machineName]);
   },
-  start: function () {
-    return util.exec([this.command(), '-D', 'start', NAME]);
+  start: function (machineName = this.name()) {
+    return util.exec([this.command(), '-D', 'start', machineName]);
   },
-  stop: function () {
-    return util.exec([this.command(), 'stop', NAME]);
+  stop: function (machineName = this.name()) {
+    return util.exec([this.command(), 'stop', machineName]);
   },
-  upgrade: function () {
-    return util.exec([this.command(), 'upgrade', NAME]);
+  upgrade: function (machineName = this.name()) {
+    return util.exec([this.command(), 'upgrade', machineName]);
   },
-  rm: function () {
-    return util.exec([this.command(), 'rm', '-f', NAME]);
+  rm: function (machineName = this.name()) {
+    return util.exec([this.command(), 'rm', '-f', machineName]);
   },
-  ip: function () {
-    return util.exec([this.command(), 'ip', NAME]).then(stdout => {
+  ip: function (machineName = this.name()) {
+    return util.exec([this.command(), 'ip', machineName]).then(stdout => {
       return Promise.resolve(stdout.trim().replace('\n', ''));
     });
   },
-  regenerateCerts: function () {
-    return util.exec([this.command(), 'tls-regenerate-certs', '-f', NAME]);
+  regenerateCerts: function (machineName = this.name()) {
+    return util.exec([this.command(), 'tls-regenerate-certs', '-f', machineName]);
   },
-  state: function () {
-    return this.info().then(info => {
+  state: function (machineName = this.name()) {
+    return this.info(machineName).then(info => {
       return info ? info.state : null;
     });
   },
-  disk: function () {
-    return util.exec([this.command(), 'ssh', NAME, 'df']).then(stdout => {
+  disk: function (machineName = this.name()) {
+    return util.exec([this.command(), 'ssh', machineName, 'df']).then(stdout => {
       try {
         var lines = stdout.split('\n');
         var dataline = _.find(lines, function (line) {
@@ -107,8 +107,8 @@ var DockerMachine = {
       }
     });
   },
-  memory: function () {
-    return util.exec([this.command(), 'ssh', NAME, 'free -m']).then(stdout => {
+  memory: function (machineName = this.name()) {
+    return util.exec([this.command(), 'ssh', machineName, 'free -m']).then(stdout => {
       try {
         var lines = stdout.split('\n');
         var dataline = _.find(lines, function (line) {
@@ -133,8 +133,8 @@ var DockerMachine = {
       }
     });
   },
-  stats: function () {
-    this.state().then(state => {
+  stats: function (machineName = this.name()) {
+    this.state(machineName).then(state => {
       if (state === 'Stopped') {
         return Promise.resolve({state: state});
       }
@@ -148,10 +148,10 @@ var DockerMachine = {
       });
     });
   },
-  dockerTerminal: function (cmd) {
+  dockerTerminal: function (cmd, machineName = this.name()) {
     if(util.isWindows()) {
       cmd = cmd || '';
-      this.info().then(machine => {
+      this.info(machineName).then(machine => {
         util.exec('start powershell.exe ' + cmd,
           {env: {
             'DOCKER_HOST' : machine.url,
@@ -162,7 +162,7 @@ var DockerMachine = {
       });
     } else {
       cmd = cmd || process.env.SHELL;
-      this.info().then(machine => {
+      this.info(machineName).then(machine => {
         util.exec([resources.terminal(), `DOCKER_HOST=${machine.url} DOCKER_CERT_PATH=${path.join(util.home(), '.docker/machine/machines/' + machine.name)} DOCKER_TLS_VERIFY=1 ${cmd}`]).then(() => {});
       });
     }


### PR DESCRIPTION
It looks like docker-machine recently changed their iso naming convention from `boot2docker.iso` to `boot2docker-virtualbox.iso` https://github.com/docker/machine/blob/master/drivers/virtualbox/virtualbox.go#L28

Furthermore the actual iso content versioning no-longer identifies itself as `Boot2Docker-v1.766` as it previously did, but rather contains docker version information, such as `Docker v1.7.1`

This patch changes the iso filename and version check accordingly - Furthermore the code was made a bit more flexible by passing the machine name to the methods, with an ES6 default of the machine name returned by the `name()` method.


Signed-off-by: FrenchBen <me@frenchben.com>