### PR TITLE
Add lint-eslint support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@ root: true
 ecmaFeatures:
     modules: true
     jsx: true
+    arrowFunctions: true
+    blockBindings: true
+
 env:
     node: true
     es6: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,103 @@
+root: true
+
+ecmaFeatures:
+    modules: true
+    jsx: true
+env:
+    node: true
+    es6: true
+    browser: true
+
+extends:
+    "eslint:recommended"
+
+rules:
+    indent: [2, 2, {SwitchCase: 1}]
+    brace-style: [2, "1tbs"]
+    camelcase: [2, { properties: "never" }]
+    callback-return: [2, ["cb", "callback", "next"]]
+    comma-spacing: 2
+    comma-style: [2, "last"]
+    consistent-return: 2
+    curly: [2, "all"]
+    default-case: 2
+    dot-notation: [2, { allowKeywords: true }]
+    eol-last: 2
+    eqeqeq: 2
+    func-style: [2, "declaration"]
+    guard-for-in: 2
+    key-spacing: [2, { beforeColon: false, afterColon: true }]
+    new-cap: 2
+    new-parens: 2
+    no-alert: 2
+    no-array-constructor: 2
+    no-caller: 2
+    no-console: 0
+    no-delete-var: 2
+    no-empty-label: 2
+    no-eval: 2
+    no-extend-native: 2
+    no-extra-bind: 2
+    no-fallthrough: 2
+    no-floating-decimal: 2
+    no-implied-eval: 2
+    no-invalid-this: 2
+    no-iterator: 2
+    no-label-var: 2
+    no-labels: 2
+    no-lone-blocks: 2
+    no-loop-func: 2
+    no-mixed-spaces-and-tabs: [2, false]
+    no-multi-spaces: 2
+    no-multi-str: 2
+    no-native-reassign: 2
+    no-nested-ternary: 2
+    no-new: 2
+    no-new-func: 2
+    no-new-object: 2
+    no-new-wrappers: 2
+    no-octal: 2
+    no-octal-escape: 2
+    no-process-exit: 2
+    no-proto: 2
+    no-redeclare: 2
+    no-return-assign: 2
+    no-script-url: 2
+    no-sequences: 2
+    no-shadow: 2
+    no-shadow-restricted-names: 2
+    no-spaced-func: 2
+    no-trailing-spaces: 2
+    no-undef: 2
+    no-undef-init: 2
+    no-undefined: 2
+    no-underscore-dangle: 2
+    no-unused-expressions: 2
+    no-unused-vars: [2, {vars: "all", args: "after-used"}]
+    no-use-before-define: 2
+    no-with: 2
+    quotes: [2, "single"]
+    radix: 2
+    semi: 2
+    semi-spacing: [2, {before: false, after: true}]
+    space-after-keywords: [2, "always"]
+    space-before-blocks: 2
+    space-before-function-paren: [2, "always"]
+    space-infix-ops: 2
+    space-return-throw-case: 2
+    space-unary-ops: [2, {words: true, nonwords: false}]
+    spaced-comment: [2, "always", { exceptions: ["-"]}]
+    strict: [2, "global"]
+    valid-jsdoc: [2, { prefer: { "return": "returns"}}]
+    wrap-iife: 2
+    yoda: [2, "never"]
+
+    # Previously on by default in node environment
+    no-catch-shadow: 0
+    no-console: 0
+    no-mixed-requires: 2
+    no-new-require: 2
+    no-path-concat: 2
+    no-process-exit: 2
+    global-strict: [0, "always"]
+    handle-callback-err: [2, "err"]

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel": "^5.1.10",
     "babel-jest": "^5.2.0",
     "electron-prebuilt": "^0.27.3",
+    "eslint": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.1",
     "grunt-chmod": "^1.0.3",


### PR DESCRIPTION
In order to keep code clean and future pull request up to standard, I propose to integrate eslint as part of the code. 

The rules can be modified as needed, as they were taken mainly from:
 https://github.com/eslint/eslint/blob/master/.eslintrc

Atom.io packages:
* linter
* linter-eslint