### PR TITLE
Fixing links here so they work OOB

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,8 +21,7 @@ software released under the Apache 2.0 license.
 ### How can I contribute to Kitematic?
 
 We always welcome (and deeply appreciate!) new contributions to the project. The
-best way to start contributing to Kitematic is to review our doc on
-[contributing](https://github.com/kitematic/kitematic/blob/master/CONTRIBUTING.md).
+best way to start contributing to Kitematic is to review our doc on <a href="https://github.com/kitematic/kitematic/blob/master/CONTRIBUTING.md">contributing</a>.
 
 ### How does Kitematic work with Docker?
 
@@ -31,8 +30,9 @@ the Docker Remote API.
 
 ### Which platforms does Kitematic support?
 
-Right now Kitematic works on Mac OS X and Windows. Linux is planned in the future.  Review our product 
-[roadmap](https://github.com/kitematic/kitematic/blob/master/ROADMAP.md) for more information.
+Right now Kitematic works on Mac OS X and Windows. Linux is planned in the
+future.  Review our product <a
+href="https://github.com/kitematic/kitematic/blob/master/ROADMAP.md">roadmap</a>.
 
 ### Why does Kitematic collect usage analytics and bug reports?
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -29,8 +29,8 @@ commands on the command line:
 - `docker-machine create -d virtualbox dev`
 
 Then re-open Kitematic. This usually fixes the issue, but if it persists, feel
-free to view our [existing GitHub
-issues](https://github.com/kitematic/kitematic/issues?q=is%3Aopen+is%3Aissue+label%3Abug).
+free to view our <a href="https://github.com/kitematic/kitematic/issues?q=is%3Aopen+is%3Aissue+label%3Abug">existing GitHub
+issues</a>.
 
 ## Contributing Fixes
 
@@ -46,6 +46,5 @@ if you're looking to help fix specific issues around VM provisioning.
 
 ## View All Issues
 
-For a full list of Kitematic bugs or issues see our [GitHub
-issues](https://github.com/kitematic/kitematic/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
-labelled as `bug`.
+For a full list of Kitematic bugs or issues see our <a href="https://github.com/kitematic/kitematic/issues?q=is%3Aopen+is%3Aissue+label%3Abug">existing GitHub
+issues</a> labelled as `bug`.


### PR DESCRIPTION
- The Markdown links are being processed by the scripts and stripping of the .md
- using <a> tags prevents the processing and they work OOB

Signed-off-by: Mary Anthony <mary@docker.com>