### PR TITLE
Use new forgot password link

### DIFF
--- a/src/components/AccountLogin.react.js
+++ b/src/components/AccountLogin.react.js
@@ -60,7 +60,7 @@ module.exports = React.createClass({
   },
 
   handleClickForgotPassword: function () {
-    shell.openExternal('https://hub.docker.com/account/forgot-password/');
+    shell.openExternal('https://hub.docker.com/reset-password/');
   },
 
   render: function () {


### PR DESCRIPTION
Fixes `404 Not Found` when trying to use the Forgot Password link.