### PR TITLE
Reset docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Kitematic",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": "Kitematic",
   "description": "Simple Docker Container management for Mac OS X.",
   "homepage": "https://kitematic.com/",
@@ -23,13 +23,13 @@
     }
   ],
   "docker-version": "1.8.1",
-  "docker-machine-version": "0.4.0",
+  "docker-machine-version": "0.4.1",
   "electron-version": "0.27.2",
-  "virtualbox-version": "5.0.0",
-  "virtualbox-filename": "VirtualBox-5.0.0.pkg",
-  "virtualbox-filename-win": "VirtualBox-5.0.0.exe",
-  "virtualbox-checksum": "9aa3746c508643cfd70093f484ac0a64e02438d740020e294d65a7fd409bdb3d",
-  "virtualbox-checksum-win": "0ca898eb23e20506a28bf84514536ba5455cc6a35234ea096245e42ee113e617",
+  "virtualbox-version": "5.0.2",
+  "virtualbox-filename": "VirtualBox-5.0.2.pkg",
+  "virtualbox-filename-win": "VirtualBox-5.0.2.exe",
+  "virtualbox-checksum": "384414edab277c376a2ac3d02e5f316434fa4d54d31db44dc85b6e560eda4143",
+  "virtualbox-checksum-win": "a8183d21566fc6cb327e4b71303fa0d04fc6cd079ba83d66818d18c5ef427037",
   "dependencies": {
     "alt": "^0.16.2",
     "ansi-to-html": "0.3.0",


### PR DESCRIPTION
Reset the docs to the current master.
We need to do this so that I can do changes for 1.9 without polluting the 1.8 material
I have publishes next week for new DTR and Hub is coming up