### PR TITLE
Simple kitematic cfg support for VM

### DIFF
--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -10,7 +10,14 @@ var DockerMachine = {
     return resources.dockerMachine();
   },
   name: function () {
-    return 'default';
+    var vmname;
+    var kitematicfg = util.kitematicfg();
+    if (kitematicfg.virtualbox && kitematicfg.virtualbox.name) {
+      vmname = kitematicfg.virtualbox.name;
+    } else {
+      vmname = 'default';
+    }
+    return vmname;
   },
   isoversion: function (machineName = this.name()) {
     try {
@@ -54,7 +61,14 @@ var DockerMachine = {
     });
   },
   create: function (machineName = this.name()) {
-    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', '2048', machineName]);
+    var memory;
+    var kitematicfg = util.kitematicfg();
+    if (kitematicfg.virtualbox && kitematicfg.virtualbox.memory) {
+      memory = kitematicfg.virtualbox.memory;
+    } else {
+      memory = '2048';
+    }
+    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', memory, machineName]);
   },
   start: function (machineName = this.name()) {
     return util.exec([this.command(), '-D', 'start', machineName]);

--- a/src/utils/DockerMachineUtil.js
+++ b/src/utils/DockerMachineUtil.js
@@ -61,14 +61,19 @@ var DockerMachine = {
     });
   },
   create: function (machineName = this.name()) {
-    var memory;
+    var memory, hostonlyCIDR;
     var kitematicfg = util.kitematicfg();
     if (kitematicfg.virtualbox && kitematicfg.virtualbox.memory) {
       memory = kitematicfg.virtualbox.memory;
     } else {
       memory = '2048';
     }
-    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', memory, machineName]);
+    if (kitematicfg.virtualbox.hostonlyCIDR) {
+      hostonlyCIDR = kitematicfg.virtualbox.hostonlyCIDR;
+    } else {
+      hostonlyCIDR = '192.168.99.1/24';
+    }
+    return util.exec([this.command(), '-D', 'create', '-d', 'virtualbox', '--virtualbox-memory', memory, '--virtualbox-hostonly-cidr', hostonlyCIDR, machineName]);
   },
   start: function (machineName = this.name()) {
     return util.exec([this.command(), '-D', 'start', machineName]);

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -84,6 +84,13 @@ module.exports = {
     } catch (err) {}
     return settingsjson;
   },
+  kitematicfg: function () {
+    var kitematicfg = {};
+    try {
+      kitematicfg = JSON.parse(fs.readFileSync(path.join(this.home(), '.kitematicfg'), 'utf8'));
+    } catch (err) {}
+    return kitematicfg;
+  },
   isOfficialRepo: function (name) {
     if (!name || !name.length) {
       return false;


### PR DESCRIPTION
This is a quick mod to allow 'advance' users to point Kitematic to their VM and if the VM doesn't exist, create it with the optional memory size.

Filename and location: `~/.kitematicfg`

Expected format:
```json
{
    "virtualbox": {
        "name": "default",
        "memory": "2048"
    }
}
```

Signed-off-by: FrenchBen <me(at)frenchben.com>