### PR TITLE
Fixed start/stop issues

### DIFF
--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -262,7 +262,7 @@ export default {
   },
 
   restart (name) {
-    this.client.getContainer(name).stop(stopError => {
+    this.client.getContainer(name).stop({t: 10}, stopError => {
       if (stopError && stopError.statusCode !== 304) {
         containerServerActions.error({name, stopError});
         return;
@@ -278,7 +278,7 @@ export default {
   },
 
   stop (name) {
-    this.client.getContainer(name).stop(error => {
+    this.client.getContainer(name).stop({t: 10}, error => {
       if (error && error.statusCode !== 304) {
         containerServerActions.error({name, error});
         return;


### PR DESCRIPTION
This fixes the issue seen in many daemons such as https://github.com/kitematic/kitematic/issues/746 - By default the docker CLI uses a timeout of 10s before killing the process, Kitematic did not, which caused issues when a container had a cleanup method on shutdown.

This patch adds the same 10seconds wait time before killing the container.

Signed-off-by: FrenchBen <me(at)frenchben.com>