### PR TITLE
remove non-working ACCESS URL from home page and replace it with simple IP & PORT (same as on settings page)

### DIFF
--- a/src/components/ContainerHomePreview.react.js
+++ b/src/components/ContainerHomePreview.react.js
@@ -69,11 +69,11 @@ var ContainerHomePreview = React.createClass({
     } else {
       var ports = _.map(_.pairs(this.props.ports), pair => {
         var key = pair[0];
-        var val = pair[1];
+        var {ip, port, url, error} = pair[1];
         return (
           <tr key={key}>
             <td>{key}</td>
-            <td>{val.display}</td>
+            <td>{ip}: {port}</td>
           </tr>
         );
       });
@@ -92,7 +92,7 @@ var ContainerHomePreview = React.createClass({
               <thead>
                 <tr>
                   <th>DOCKER PORT</th>
-                  <th>ACCESS URL</th>
+                  <th>IP & PORT</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/components/ContainerSettingsPorts.react.js
+++ b/src/components/ContainerSettingsPorts.react.js
@@ -108,7 +108,7 @@ var ContainerSettingsPorts = React.createClass({
             <thead>
               <tr>
                 <th>DOCKER PORT</th>
-                <th>MAC IP:PORT</th>
+                <th>IP & PORT</th>
                 <th></th>
               </tr>
             </thead>


### PR DESCRIPTION
rationale behind this is that most containers don't have any web UI to use as "access url". maybe I am wrong but usually I use KItematic for some databases like postgres or mongo or redis etc.