### PR TITLE
Enabled scrolling on new container

### DIFF
--- a/styles/new-container.less
+++ b/styles/new-container.less
@@ -31,6 +31,7 @@
   display: flex;
   flex: 1 auto;
   flex-direction: column;
+  overflow: auto;
 
   .spinner {
     display: inline-block;


### PR DESCRIPTION
Somehow we lost the ability to scroll on the New/Search Container page. This adds some overflow magic.
Signed-off-by: FrenchBen <me(at)frenchben.com>