### PR TITLE
Add stopping state to fix immediately killing containers

### DIFF
--- a/src/actions/ContainerServerActions.js
+++ b/src/actions/ContainerServerActions.js
@@ -13,7 +13,9 @@ class ContainerServerActions {
       'started',
       'unmuted',
       'updated',
-      'waiting'
+      'waiting',
+      'kill',
+      'stopped'
     );
   }
 }

--- a/src/components/ContainerDetailsHeader.react.js
+++ b/src/components/ContainerDetailsHeader.react.js
@@ -9,12 +9,14 @@ var ContainerDetailsHeader = React.createClass({
 
     if (this.props.container.State.Updating) {
       state = <span className="status downloading">UPDATING</span>;
-    } else if (this.props.container.State.Running && !this.props.container.State.Paused && !this.props.container.State.ExitCode && !this.props.container.State.Restarting) {
-      state = <span className="status running">RUNNING</span>;
-    } else if (this.props.container.State.Restarting) {
-      state = <span className="status restarting">RESTARTING</span>;
+    } else if (this.props.container.State.Stopping) {
+      state = <span className="status running">STOPPING</span>;
     } else if (this.props.container.State.Paused) {
       state = <span className="status paused">PAUSED</span>;
+    } else if (this.props.container.State.Restarting) {
+      state = <span className="status restarting">RESTARTING</span>;
+    } else if (this.props.container.State.Running && !this.props.container.State.ExitCode) {
+      state = <span className="status running">RUNNING</span>;
     } else if (this.props.container.State.Starting) {
       state = <span className="status running">STARTING</span>;
     } else if (this.props.container.State.Downloading) {

--- a/src/components/ContainerDetailsSubheader.react.js
+++ b/src/components/ContainerDetailsSubheader.react.js
@@ -13,33 +13,33 @@ var ContainerDetailsSubheader = React.createClass({
   },
   disableRun: function () {
     if (!this.props.container) {
-      return false;
+      return true;
     }
     return (!this.props.container.State.Running || !this.props.defaultPort || this.props.container.State.Updating);
   },
   disableRestart: function () {
     if (!this.props.container) {
-      return false;
+      return true;
     }
-    return (this.props.container.State.Downloading || this.props.container.State.Restarting || this.props.container.State.Updating);
+    return (this.props.container.State.Stopping || this.props.container.State.Downloading || this.props.container.State.Restarting || this.props.container.State.Updating);
   },
   disableStop: function () {
     if (!this.props.container) {
-      return false;
+      return true;
     }
-    return (this.props.container.State.Downloading || this.props.container.State.ExitCode || !this.props.container.State.Running || this.props.container.State.Updating);
+    return (this.props.container.State.Stopping || this.props.container.State.Downloading || this.props.container.State.ExitCode || !this.props.container.State.Running || this.props.container.State.Updating);
   },
   disableStart: function () {
     if (!this.props.container) {
-      return false;
+      return true;
     }
     return (this.props.container.State.Downloading || this.props.container.State.Running || this.props.container.State.Updating);
   },
   disableTerminal: function () {
     if (!this.props.container) {
-      return false;
+      return true;
     }
-    return (!this.props.container.State.Running || this.props.container.State.Updating);
+    return (this.props.container.State.Stopping || !this.props.container.State.Running || this.props.container.State.Updating);
   },
   disableTab: function () {
     if (!this.props.container) {

--- a/src/stores/ContainerStore.js
+++ b/src/stores/ContainerStore.js
@@ -38,10 +38,22 @@ class ContainerStore {
     }
   }
 
-  stop ({name}) {
+  stopped ({id}) {
     let containers = this.containers;
-    if (containers[name]) {
-      containers[name].State.Running = false;
+    let container = _.find(_.values(containers), c => c.Id === id || c.Name === id);
+
+    if (containers[container.Name]) {
+      containers[container.Name].State.Stopping = false;
+      this.setState({containers});
+    }
+  }
+
+  kill ({id}) {
+    let containers = this.containers;
+    let container = _.find(_.values(containers), c => c.Id === id || c.Name === id);
+
+    if (containers[container.Name]) {
+      containers[container.Name].State.Stopping = true;
       this.setState({containers});
     }
   }
@@ -69,6 +81,10 @@ class ContainerStore {
   update ({name, container}) {
     let containers = this.containers;
     if (containers[name] && containers[name].State && containers[name].State.Updating) {
+      return;
+    }
+
+    if (containers[name].State.Stopping) {
       return;
     }
 
@@ -113,9 +129,7 @@ class ContainerStore {
 
   destroyed ({id}) {
     let containers = this.containers;
-    let container = _.find(_.values(this.containers), container => {
-      return container.Id === id || container.Name === id;
-    });
+    let container = _.find(_.values(containers), c => c.Id === id || c.Name === id);
 
     if (container && container.State && container.State.Updating) {
       return;

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -269,7 +269,7 @@ export default {
   },
 
   restart (name) {
-    this.client.getContainer(name).stop(stopError => {
+    this.client.getContainer(name).stop({t: 5}, stopError => {
       if (stopError && stopError.statusCode !== 304) {
         containerServerActions.error({name, stopError});
         return;
@@ -285,7 +285,7 @@ export default {
   },
 
   stop (name) {
-    this.client.getContainer(name).stop(error => {
+    this.client.getContainer(name).stop({t: 5}, error => {
       if (error && error.statusCode !== 304) {
         containerServerActions.error({name, error});
         return;
@@ -341,12 +341,16 @@ export default {
       stream.on('data', json => {
         let data = JSON.parse(json);
 
-        if (data.status === 'pull' || data.status === 'untag' || data.status === 'delete') {
+        if (data.status === 'pull' || data.status === 'untag' || data.status === 'delete' || data.status === 'attach') {
           return;
         }
 
         if (data.status === 'destroy') {
           containerServerActions.destroyed({id: data.id});
+        } else if (data.status === 'kill') {
+          containerServerActions.kill({id: data.id});
+        } else if (data.status === 'stop') {
+          containerServerActions.stopped({id: data.id});
         } else if (data.id) {
           this.fetchContainer(data.id);
         }


### PR DESCRIPTION
- The docker daemon emits `kill` events when containers are stopped. We can use this to disable the start, restart and exec buttons while the container shuts down.

- Added a 5 second timeout