### PR TITLE
Added port type support - fixes #344

### DIFF
--- a/src/components/ContainerHomePreview.react.js
+++ b/src/components/ContainerHomePreview.react.js
@@ -34,7 +34,7 @@ var ContainerHomePreview = React.createClass({
       metrics.track('Opened In Browser', {
         from: 'preview'
       });
-      shell.openExternal(this.props.ports[this.props.defaultPort].url);
+      shell.openExternal('http://' + this.props.ports[this.props.defaultPort].url);
     }
   },
 
@@ -48,7 +48,7 @@ var ContainerHomePreview = React.createClass({
   render: function () {
     var preview;
     if (this.props.defaultPort) {
-      var frame = React.createElement('webview', {className: 'frame', id: 'webview', src: this.props.ports[this.props.defaultPort].url, autosize: 'on'});
+      var frame = React.createElement('webview', {className: 'frame', id: 'webview', src: 'http://' + this.props.ports[this.props.defaultPort].url, autosize: 'on'});
       preview = (
         <div className="web-preview wrapper">
           <div className="widget">
@@ -72,7 +72,7 @@ var ContainerHomePreview = React.createClass({
         var val = pair[1];
         return (
           <tr key={key}>
-            <td>{key}</td>
+            <td>{key + '/' + val.portType}</td>
             <td>{val.url}</td>
           </tr>
         );

--- a/src/utils/ContainerUtil.js
+++ b/src/utils/ContainerUtil.js
@@ -28,20 +28,22 @@ var ContainerUtil = {
     }
     var res = {};
     var ip = docker.host;
-    var ports = (container.NetworkSettings.Ports) ? container.NetworkSettings.Ports : (container.HostConfig.PortBindings) ? container.HostConfig.PortBindings : container.Config.ExposedPorts;
+    var ports = (container.NetworkSettings.Ports) ? container.NetworkSettings.Ports : ((container.HostConfig.PortBindings) ? container.HostConfig.PortBindings : container.Config.ExposedPorts);
     _.each(ports, function (value, key) {
-      var dockerPort = key.split('/')[0];
+      var [dockerPort, portType] = key.split('/');
       var localUrl = null;
-      var localUrlDisplay = null;
       var port = null;
+
       if (value && value.length) {
-        var port = value[0].HostPort;
-        localUrl = 'http://' + ip + ':' + port;
+        port = value[0].HostPort;
       }
+      localUrl = (port) ? ip + ':' + port : ip + ':' + '<not set>';
+
       res[dockerPort] = {
         url: localUrl,
         ip: ip,
-        port: port
+        port: port,
+        portType: portType
       };
     });
     return res;

--- a/src/utils/DockerUtil.js
+++ b/src/utils/DockerUtil.js
@@ -231,6 +231,19 @@ export default {
         existingData.Tty = existingData.Config.Tty;
         existingData.OpenStdin = existingData.Config.OpenStdin;
       }
+      let networking = _.extend(existingData.NetworkSettings, data.NetworkSettings);
+      if (networking && networking.Ports) {
+        let exposed = _.reduce(networking.Ports, (res, value, key) => {
+          res[key] = {};
+          return res;
+        }, {});
+        data = _.extend(data, {
+          HostConfig: {
+            PortBindings: networking.Ports
+          },
+          ExposedPorts: exposed
+        });
+      }
 
       var fullData = _.extend(existingData, data);
       this.createContainer(name, fullData);

--- a/styles/container-home.less
+++ b/styles/container-home.less
@@ -48,6 +48,7 @@
               }
             }
             td {
+              -webkit-user-select: auto;
               border-color: @color-divider;
               &.right {
                 text-align: right;
@@ -165,7 +166,7 @@
             .text {
               margin-top: 0.3rem;
               margin-left: 1rem;
-              width: 180px;  
+              width: 180px;
               text-overflow: ellipsis;
               white-space: nowrap;
               overflow: hidden;


### PR DESCRIPTION
Port types are now displayed on the home preview:
![home-preview](https://cloud.githubusercontent.com/assets/3965324/11051300/dfdf7528-8702-11e5-83b2-39c04af75a87.png)

Additionally port types can be modified as needed and are consistent after start/stop/updates:
![port-settings](https://cloud.githubusercontent.com/assets/3965324/11051307/ecb0a222-8702-11e5-86f0-8e410c1e78ef.png)



Signed-off-by: French Ben <me+git@frenchben.com>